### PR TITLE
feat(profile): add followed campaigns page

### DIFF
--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -822,6 +822,12 @@
       "payment_method_required": "Select a payment method"
     }
   },
+  "followed_campaigns": {
+    "title": "Campaigns I follow",
+    "subtitle": "See the campaigns you are following.",
+    "empty_title": "You are not following any campaigns yet",
+    "empty_subtitle": "Campaigns you follow will appear here."
+  },
   "leaderboard": {
     "hero_badge": "Rankings",
     "title": "Donor Leaderboard",

--- a/web/i18n/es.json
+++ b/web/i18n/es.json
@@ -822,6 +822,12 @@
       "payment_method_required": "Selecciona un método de pago"
     }
   },
+  "followed_campaigns": {
+    "title": "Campañas que sigo",
+    "subtitle": "Mira las campañas que estás siguiendo.",
+    "empty_title": "Aún no sigues ninguna campaña",
+    "empty_subtitle": "Las campañas que sigas aparecerán aquí."
+  },
   "leaderboard": {
     "hero_badge": "Clasificación",
     "title": "Clasificación de Donantes",

--- a/web/i18n/pt.json
+++ b/web/i18n/pt.json
@@ -822,6 +822,12 @@
       "payment_method_required": "Selecione uma forma de pagamento"
     }
   },
+  "followed_campaigns": {
+    "title": "Campanhas que sigo",
+    "subtitle": "Veja as campanhas que você está acompanhando.",
+    "empty_title": "Você ainda não segue nenhuma campanha",
+    "empty_subtitle": "As campanhas que você seguir aparecerão aqui."
+  },
   "leaderboard": {
     "hero_badge": "Ranking",
     "title": "Ranking de Doadores",

--- a/web/src/app/profile/followed-campaigns/page.tsx
+++ b/web/src/app/profile/followed-campaigns/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { Spinner } from '@heroui/react';
+import { BookmarkIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { ProfileSidebar } from '../profile-sidebar';
+import { CampaignCard } from '@/components/campaign/campaign-card';
+import { useListFavoritedCampaigns } from '@/lib/http/generated';
+import type { Campaign } from '@/models/campaign';
+
+const calculateDaysRemaining = (expiresAt?: string | null) => {
+  if (!expiresAt) return undefined;
+  const diffMs = new Date(expiresAt).getTime() - Date.now();
+  return Math.max(0, Math.ceil(diffMs / (1000 * 60 * 60 * 24)));
+};
+
+const FollowedCampaignsPage = () => {
+  const t = useTranslations('followed_campaigns');
+  const { data: favoritedCampaigns, isLoading } = useListFavoritedCampaigns();
+
+  const campaigns: Campaign[] = (favoritedCampaigns ?? []).map((campaign) => {
+    const goal = campaign.goalCents ?? 0;
+    const raised = campaign.amountRaisedCents ?? 0;
+    const progress = goal > 0 ? Math.round((raised / goal) * 100) : 0;
+
+    return {
+      ...campaign,
+      title: campaign.title ?? '',
+      progress,
+      raised,
+      goal,
+      daysRemaining: calculateDaysRemaining(campaign.expiresAt),
+    };
+  });
+
+  return (
+    <div className="max-w-[1280px] mx-auto w-full my-10 px-4">
+      <div className="flex gap-8">
+        <ProfileSidebar />
+
+        <main className="flex-1 space-y-6">
+          <div>
+            <h1 className="text-2xl font-semibold mb-2">{t('title')}</h1>
+            <p className="text-sm text-default-500">
+              {t('subtitle')}
+            </p>
+          </div>
+
+          {isLoading ? (
+            <div className="flex justify-center items-center py-20">
+              <Spinner size="lg" />
+            </div>
+          ) : campaigns.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <BookmarkIcon size={48} className="text-default-300 mb-4" />
+              <p className="text-lg font-medium text-default-600">
+                {t('empty_title')}
+              </p>
+              <p className="text-sm text-default-400 mt-1">
+                {t('empty_subtitle')}
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {campaigns.map((campaign) => (
+                <CampaignCard key={campaign.slug} campaign={campaign} />
+              ))}
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default FollowedCampaignsPage;

--- a/web/src/app/profile/profile-sidebar.tsx
+++ b/web/src/app/profile/profile-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { Avatar, Button, Card, CardBody } from '@heroui/react';
 import {
+  Bookmark,
   CameraIcon,
   Heart,
   Megaphone,
@@ -19,6 +20,7 @@ import { useRef } from 'react';
 
 const navigationItems = [
   { label: 'Minhas Campanhas', href: '/profile/campaigns', icon: Megaphone },
+  { label: 'Campanhas que Sigo', href: '/profile/followed-campaigns', icon: Bookmark },
   { label: 'Minhas Doações', href: '/profile/donations', icon: Heart },
   { label: 'Extrato', href: '/profile/statement', icon: Receipt },
   { label: 'Notificações', href: '/profile/notifications', icon: Bell },


### PR DESCRIPTION
## Summary

Add a new page at /profile/followed-campaigns where users can see the campaigns they follow. Also added a nav item in the profile sidebar.

## Context

Closes https://linear.app/benevolus/issue/BEN-56/listar-campanhas-seguidas-no-perfil-do-usuario

![chrome_Fu0FEecpLZ](https://github.com/user-attachments/assets/34a72f9f-1819-4e8e-9060-dc0f9a47dc00)
