### PR TITLE
fix(campaigns): open public page in new tab and add i18n

### DIFF
--- a/web/i18n/en.json
+++ b/web/i18n/en.json
@@ -1318,5 +1318,8 @@
       "tokenization_failed": "Error processing card. Please check your details and try again.",
       "zip_code_required": "ZIP code is required"
     }
+  },
+  "campaignDashboard": {
+    "view_public_page": "View public page"
   }
 }

--- a/web/i18n/es.json
+++ b/web/i18n/es.json
@@ -1318,5 +1318,8 @@
       "tokenization_failed": "Error al procesar la tarjeta. Verifica los datos e inténtalo de nuevo.",
       "zip_code_required": "Ingrese el código postal"
     }
+  },
+  "campaignDashboard": {
+    "view_public_page": "Ver página pública"
   }
 }

--- a/web/i18n/pt.json
+++ b/web/i18n/pt.json
@@ -1318,5 +1318,8 @@
       "tokenization_failed": "Erro ao processar o cartão. Verifique os dados e tente novamente.",
       "zip_code_required": "Informe o CEP"
     }
+  },
+  "campaignDashboard": {
+    "view_public_page": "Ver página pública"
   }
 }

--- a/web/src/app/profile/campaigns/[id]/page.tsx
+++ b/web/src/app/profile/campaigns/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { useTranslations } from 'next-intl';
 
 import { ProfileSidebar } from '../../profile-sidebar';
 import { RecentDonationsList } from './recent-donations-list';
@@ -74,6 +75,7 @@ const CampaignDashboardPage = ({
   params: Promise<{ id: string }>;
 }) => {
   const { id } = use(params);
+  const t = useTranslations('campaignDashboard');
 
   const { data: campaign, isLoading: isLoadingCampaign } = useGetCampaign(id);
   const { data: donationsResponse, isLoading: isLoadingDonations } =
@@ -151,11 +153,12 @@ const CampaignDashboardPage = ({
             <Button
               as={Link}
               href={`/${campaign.slug}`}
+              target="_blank"
               variant="flat"
               size="sm"
               endContent={<ExternalLink size={16} />}
             >
-              Ver página pública
+              {t('view_public_page')}
             </Button>
           </div>
 


### PR DESCRIPTION
## Summary
Add target="_blank" to the "View public page" button on the campaign dashboard and replace hardcoded text with i18n translation key.

## Context
https://linear.app/benevolus/issue/BEN-44/botao-ver-pagina-publica-deve-abrir-em-nova-aba-e-usar-i18n

![chrome_qBSTL3Ltnv](https://github.com/user-attachments/assets/744765d0-baa3-4e11-a672-d6fb576a2e4a)
