### PR TITLE
fix(navbar): remove "Benevolus" text

### DIFF
--- a/web/src/components/layout/navbar.tsx
+++ b/web/src/components/layout/navbar.tsx
@@ -69,11 +69,10 @@ export const Navbar = () => {
       <NavbarContent className="basis-1/5 sm:basis-full" justify="start">
         <NavbarBrand as="li" className="gap-3 max-w-fit">
           <NextLink
-            className="flex justify-start items-center gap-3 group"
+            className="flex justify-start items-center group"
             href="/"
           >
             <LogoIcon className="text-primary" size={40} />
-            <span className="font-bold text-xl">{siteConfig.name}</span>
           </NextLink>
         </NavbarBrand>
         <ul className="hidden lg:flex gap-6 justify-start ml-4 flex-shrink-0">


### PR DESCRIPTION
Remove the "Benevolus" text from the navbar, keeping only the logo icon.

https://linear.app/benevolus/issue/BEN-43/remover-texto-benevolus-da-navbar-manter-apenas-o-icone


<img width="1920" height="953" alt="image" src="https://github.com/user-attachments/assets/6188fdb9-20ff-4b5f-a042-e9725a65e0a0" />
